### PR TITLE
Fix chessboard click events

### DIFF
--- a/script.js
+++ b/script.js
@@ -97,6 +97,7 @@ function renderChessboard() {
         pieceImage.style.height = '100%';
         square.appendChild(pieceImage);
       }
+      square.addEventListener('click', onSquareClick);
       chessboard.appendChild(square);
     }
   }


### PR DESCRIPTION
## Summary
- attach click handlers to generated chessboard squares

## Testing
- `node -e "require('fs').readFileSync('script.js')" >/dev/null && echo parsed`

------
https://chatgpt.com/codex/tasks/task_e_6843ec2bf3288327aad18c4a1ce4eb10