### PR TITLE
Fix fetch header case

### DIFF
--- a/script.js
+++ b/script.js
@@ -596,7 +596,7 @@ async function sendChatMessageToLLM(message) {
     const response = await fetch(CHAT_LLM_URL, {
       method: 'POST',
       body: JSON.stringify(chatPayload),
-      headers: { 'Content-type': 'application/json; charset=UTF-8', 'Authorization': `Bearer ${apiKey}`},
+      headers: { 'Content-Type': 'application/json; charset=UTF-8', 'Authorization': `Bearer ${apiKey}`},
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- ensure the fetch request in `sendChatMessageToLLM` uses `Content-Type` header

## Testing
- `grep -n "Content-Type" -n script.js`

------
https://chatgpt.com/codex/tasks/task_e_6843edd023408327b73f4214bd4734bb