### PR TITLE
Implement chess move TODOs

### DIFF
--- a/script.js
+++ b/script.js
@@ -53,6 +53,11 @@ const initialBoardSetup = {
 
 let currentBoard = JSON.parse(JSON.stringify(initialBoardSetup));
 let gameActive = true; // Flag to control if moves can be made
+let lastMove = null;
+const castlingRights = {
+  white: { kingMoved: false, rookA: false, rookH: false },
+  black: { kingMoved: false, rookA: false, rookH: false }
+};
 
 // --- Helper function for image alt text ---
 function getPieceNameFromPath(imagePath) {
@@ -144,7 +149,14 @@ function isValidPawnMove(fromRow, fromCol, toRow, toCol, pieceColor, board) {
       return true;
     }
   }
-  // TODO: En passant
+  // En passant
+  if (Math.abs(fromCol - toCol) === 1 && board[toRow]?.[toCol] === undefined && toRow === fromRow + direction) {
+    if (lastMove && lastMove.pieceSymbol === PIECES[opponentColor].pawn &&
+        Math.abs(lastMove.toRow - lastMove.fromRow) === 2 &&
+        lastMove.toRow === fromRow && lastMove.toCol === toCol) {
+      return true;
+    }
+  }
   return false;
 }
 
@@ -188,11 +200,32 @@ function isValidQueenMove(fromRow, fromCol, toRow, toCol, board) {
     return isValidRookMove(fromRow, fromCol, toRow, toCol, board) || isValidBishopMove(fromRow, fromCol, toRow, toCol, board);
 }
 
-function isValidKingMove(fromRow, fromCol, toRow, toCol) {
+function isValidKingMove(fromRow, fromCol, toRow, toCol, board, pieceColor) {
     const dRow = Math.abs(toRow - fromRow);
     const dCol = Math.abs(toCol - fromCol);
-    return dRow <= 1 && dCol <= 1 && (dRow + dCol > 0);
-    // TODO: Castling
+    if (dRow <= 1 && dCol <= 1 && (dRow + dCol > 0)) return true;
+
+    if (dRow === 0 && dCol === 2 && fromRow === (pieceColor === 'white' ? 7 : 0)) {
+        const rights = castlingRights[pieceColor];
+        if (rights.kingMoved) return false;
+        const opponentColor = pieceColor === 'white' ? 'black' : 'white';
+        if (toCol === 6) { // kingside
+            if (rights.rookH) return false;
+            if (board[fromRow]?.[5] || board[fromRow]?.[6]) return false;
+            if (isSquareUnderAttack(fromRow, 4, opponentColor, board) ||
+                isSquareUnderAttack(fromRow, 5, opponentColor, board) ||
+                isSquareUnderAttack(fromRow, 6, opponentColor, board)) return false;
+            return board[fromRow]?.[7] === PIECES[pieceColor].rook;
+        } else if (toCol === 2) { // queenside
+            if (rights.rookA) return false;
+            if (board[fromRow]?.[1] || board[fromRow]?.[2] || board[fromRow]?.[3]) return false;
+            if (isSquareUnderAttack(fromRow, 4, opponentColor, board) ||
+                isSquareUnderAttack(fromRow, 3, opponentColor, board) ||
+                isSquareUnderAttack(fromRow, 2, opponentColor, board)) return false;
+            return board[fromRow]?.[0] === PIECES[pieceColor].rook;
+        }
+    }
+    return false;
 }
 
 function isMoveValid(pieceSymbol, fromRow, fromCol, toRow, toCol, board) {
@@ -209,7 +242,7 @@ function isMoveValid(pieceSymbol, fromRow, fromCol, toRow, toCol, board) {
   if (pieceSymbol === PIECES.white.knight || pieceSymbol === PIECES.black.knight) return isValidKnightMove(fromRow, fromCol, toRow, toCol);
   if (pieceSymbol === PIECES.white.bishop || pieceSymbol === PIECES.black.bishop) return isValidBishopMove(fromRow, fromCol, toRow, toCol, board);
   if (pieceSymbol === PIECES.white.queen || pieceSymbol === PIECES.black.queen) return isValidQueenMove(fromRow, fromCol, toRow, toCol, board);
-  if (pieceSymbol === PIECES.white.king || pieceSymbol === PIECES.black.king) return isValidKingMove(fromRow, fromCol, toRow, toCol);
+  if (pieceSymbol === PIECES.white.king || pieceSymbol === PIECES.black.king) return isValidKingMove(fromRow, fromCol, toRow, toCol, board, pieceColor);
   return false;
 }
 
@@ -240,7 +273,49 @@ async function onSquareClick(event) {
     if (isMoveValid(pieceSymbol, fromRow, fromCol, toRow, toCol, currentBoard)) {
       const tempBoard = JSON.parse(JSON.stringify(currentBoard));
       tempBoard[toRow] = tempBoard[toRow] || {};
-      tempBoard[toRow][toCol] = pieceSymbol;
+      let pieceToPlace = pieceSymbol;
+      const color = getPieceColor(pieceSymbol);
+
+      // En passant capture
+      if ((pieceSymbol === PIECES.white.pawn || pieceSymbol === PIECES.black.pawn) &&
+          Math.abs(fromCol - toCol) === 1 && currentBoard[toRow]?.[toCol] === undefined) {
+        const captureRow = fromRow;
+        if (tempBoard[captureRow]) {
+          delete tempBoard[captureRow][toCol];
+          if (Object.keys(tempBoard[captureRow]).length === 0) delete tempBoard[captureRow];
+        }
+      }
+
+      // Castling rook movement and rights
+      if (pieceSymbol === PIECES.white.king || pieceSymbol === PIECES.black.king) {
+        castlingRights[color].kingMoved = true;
+        if (Math.abs(toCol - fromCol) === 2) {
+          if (toCol === 6) { // kingside
+            tempBoard[fromRow][5] = tempBoard[fromRow][7];
+            delete tempBoard[fromRow][7];
+            castlingRights[color].rookH = true;
+          } else if (toCol === 2) { // queenside
+            tempBoard[fromRow][3] = tempBoard[fromRow][0];
+            delete tempBoard[fromRow][0];
+            castlingRights[color].rookA = true;
+          }
+        }
+      }
+
+      if (pieceSymbol === PIECES.white.rook || pieceSymbol === PIECES.black.rook) {
+        if (fromRow === (color === 'white' ? 7 : 0)) {
+          if (fromCol === 0) castlingRights[color].rookA = true;
+          if (fromCol === 7) castlingRights[color].rookH = true;
+        }
+      }
+
+      // Pawn promotion
+      if ((pieceSymbol === PIECES.white.pawn && toRow === 0) ||
+          (pieceSymbol === PIECES.black.pawn && toRow === 7)) {
+        pieceToPlace = PIECES[color].queen;
+      }
+
+      tempBoard[toRow][toCol] = pieceToPlace;
       if (tempBoard[fromRow]) {
           delete tempBoard[fromRow][fromCol];
           if (Object.keys(tempBoard[fromRow]).length === 0) delete tempBoard[fromRow];
@@ -252,6 +327,7 @@ async function onSquareClick(event) {
         selectedPiece = null;
       } else {
         currentBoard = tempBoard;
+        lastMove = { fromRow, fromCol, toRow, toCol, pieceSymbol, doubleStep: (pieceSymbol === PIECES.white.pawn || pieceSymbol === PIECES.black.pawn) && Math.abs(toRow - fromRow) === 2 };
         selectedElement.classList.remove('selected');
         selectedPiece = null;
         renderChessboard();
@@ -328,6 +404,28 @@ function isKingInCheck(kingColor, boardState) {
   return false;
 }
 
+function isSquareUnderAttack(row, col, attackerColor, boardState) {
+  for (let r = 0; r < 8; r++) {
+    if (boardState[r]) {
+      for (let c = 0; c < 8; c++) {
+        const piece = boardState[r][c];
+        if (piece && getPieceColor(piece) === attackerColor) {
+          if (piece === PIECES[attackerColor].king) {
+            if (Math.abs(row - r) <= 1 && Math.abs(col - c) <= 1 && (row !== r || col !== c)) {
+              return true;
+            }
+          } else {
+            if (isMoveValid(piece, r, c, row, col, boardState)) {
+              return true;
+            }
+          }
+        }
+      }
+    }
+  }
+  return false;
+}
+
 function getPseudoLegalMovesForPiece(pieceSymbol, fromRow, fromCol, boardState) {
     const moves = [];
     for (let r = 0; r < 8; r++) {
@@ -395,7 +493,12 @@ function parseAlgebraicMove(moveString, playerColor, board) { // e.g., "e2e4" or
 
     const fromAlg = moveString.substring(0, 2);
     const toAlg = moveString.substring(2, 4);
-    // TODO: Handle promotion piece if present (e.g., moveString.charAt(4) for 'q', 'r', 'b', 'n')
+    let promotion = null;
+    if (moveString.length === 5) {
+        const promoChar = moveString.charAt(4).toLowerCase();
+        const map = { q: 'queen', r: 'rook', b: 'bishop', n: 'knight' };
+        if (map[promoChar]) promotion = PIECES[playerColor][map[promoChar]];
+    }
 
     const fromCoords = algebraicToCoords(fromAlg);
     const toCoords = algebraicToCoords(toAlg);
@@ -428,7 +531,8 @@ function parseAlgebraicMove(moveString, playerColor, board) { // e.g., "e2e4" or
         fromCol: fromCoords.col,
         toRow: toCoords.row,
         toCol: toCoords.col,
-        pieceSymbol: pieceSymbol // The actual piece on the 'from' square
+        pieceSymbol: pieceSymbol,
+        promotion
     };
 }
 
@@ -499,7 +603,7 @@ async function handleLLMTurn(humanLastMoveDescription) {
   const llmMoveData = await getLLMMove(currentBoard, llmPlayerColor, humanLastMoveDescription);
 
   if (llmMoveData) {
-    const { fromRow, fromCol, toRow, toCol } = llmMoveData;
+    const { fromRow, fromCol, toRow, toCol, promotion } = llmMoveData;
     const pieceSymbolToMove = currentBoard[fromRow]?.[fromCol];
 
     if (!pieceSymbolToMove || getPieceColor(pieceSymbolToMove) !== llmPlayerColor) {
@@ -510,7 +614,51 @@ async function handleLLMTurn(humanLastMoveDescription) {
     if (isMoveValid(pieceSymbolToMove, fromRow, fromCol, toRow, toCol, currentBoard)) {
       const tempBoard = JSON.parse(JSON.stringify(currentBoard));
       tempBoard[toRow] = tempBoard[toRow] || {};
-      tempBoard[toRow][toCol] = pieceSymbolToMove;
+      let pieceToPlace = pieceSymbolToMove;
+      const color = getPieceColor(pieceSymbolToMove);
+
+      // En passant capture
+      if ((pieceSymbolToMove === PIECES.white.pawn || pieceSymbolToMove === PIECES.black.pawn) &&
+          Math.abs(fromCol - toCol) === 1 && currentBoard[toRow]?.[toCol] === undefined) {
+        const captureRow = fromRow;
+        if (tempBoard[captureRow]) {
+          delete tempBoard[captureRow][toCol];
+          if (Object.keys(tempBoard[captureRow]).length === 0) delete tempBoard[captureRow];
+        }
+      }
+
+      // Castling rook movement and rights
+      if (pieceSymbolToMove === PIECES.white.king || pieceSymbolToMove === PIECES.black.king) {
+        castlingRights[color].kingMoved = true;
+        if (Math.abs(toCol - fromCol) === 2) {
+          if (toCol === 6) {
+            tempBoard[fromRow][5] = tempBoard[fromRow][7];
+            delete tempBoard[fromRow][7];
+            castlingRights[color].rookH = true;
+          } else if (toCol === 2) {
+            tempBoard[fromRow][3] = tempBoard[fromRow][0];
+            delete tempBoard[fromRow][0];
+            castlingRights[color].rookA = true;
+          }
+        }
+      }
+
+      if (pieceSymbolToMove === PIECES.white.rook || pieceSymbolToMove === PIECES.black.rook) {
+        if (fromRow === (color === 'white' ? 7 : 0)) {
+          if (fromCol === 0) castlingRights[color].rookA = true;
+          if (fromCol === 7) castlingRights[color].rookH = true;
+        }
+      }
+
+      // Promotion from algebraic move
+      if (promotion) {
+        pieceToPlace = promotion;
+      } else if ((pieceSymbolToMove === PIECES.white.pawn && toRow === 0) ||
+                 (pieceSymbolToMove === PIECES.black.pawn && toRow === 7)) {
+        pieceToPlace = PIECES[color].queen;
+      }
+
+      tempBoard[toRow][toCol] = pieceToPlace;
       if (tempBoard[fromRow]) {
         delete tempBoard[fromRow][fromCol];
         if (Object.keys(tempBoard[fromRow]).length === 0) delete tempBoard[fromRow];
@@ -522,6 +670,7 @@ async function handleLLMTurn(humanLastMoveDescription) {
       }
 
       currentBoard = tempBoard;
+      lastMove = { fromRow, fromCol, toRow, toCol, pieceSymbol: pieceSymbolToMove, doubleStep: (pieceSymbolToMove === PIECES.white.pawn || pieceSymbolToMove === PIECES.black.pawn) && Math.abs(toRow - fromRow) === 2 };
       renderChessboard();
       const llmMoveFromAlg = coordsToAlgebraic(fromRow, fromCol);
       const llmMoveToAlg = coordsToAlgebraic(toRow, toCol);


### PR DESCRIPTION
## Summary
- support en passant capture, castling logic and pawn promotion
- track last moves and castling rights to validate special moves
- parse promotion piece from algebraic notation

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6843eef935008327b40ae08aaa75666a