### PR TITLE
Fix stockfish init and keep chat width constant

### DIFF
--- a/script.js
+++ b/script.js
@@ -18,9 +18,11 @@ function initializeStockfish() {
     stockfish = new Worker('https://cdn.jsdelivr.net/npm/stockfish/stockfish.js');
     stockfish.postMessage('uci');
     console.log('Stockfish initialized');
+    addMessageToChat('Stockfish engine loaded.', 'System', 'system-info');
   } catch (err) {
     console.error('Failed to load Stockfish:', err);
     stockfish = null;
+    addMessageToChat('Stockfish engine failed to load.', 'System', 'system-warning');
   }
 }
 
@@ -893,6 +895,8 @@ difficultySelect.addEventListener('change', () => {
 // --- Initial Setup ---
 document.addEventListener('DOMContentLoaded', () => {
   loadApiKey(); // Load API key when the DOM is ready
+  loadDifficulty();
+  initializeStockfish();
 
   renderChessboard();
   addMessageToChat(`Welcome! You are playing as ${humanPlayerColor}. ${humanPlayerColor}'s turn.`, 'System', 'system');

--- a/style.css
+++ b/style.css
@@ -111,8 +111,8 @@ body {
   display: flex;
   flex-direction: column;
   gap: 20px;
-  flex-grow: 1;
-  min-width: 300px;
+  flex: 0 0 300px; /* keep chat sidebar a consistent width */
+  width: 300px;
 }
 
 #chat-window {


### PR DESCRIPTION
## Summary
- keep chat sidebar at a fixed width
- initialize Stockfish and load difficulty settings on page load
- notify the user whether Stockfish was loaded successfully

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6847b1fee7308327acb00500600a6ace